### PR TITLE
Added support for "WHO=6" command messages

### DIFF
--- a/OWNd/message.py
+++ b/OWNd/message.py
@@ -1253,6 +1253,8 @@ class OWNCommand(OWNMessage):
                 return OWNHeatingCommand(data)
             elif _who == 5:
                 return cls(data)
+            elif _who == 6:
+                return cls(data)
             elif _who == 7:
                 return cls(data)
             elif _who == 9:


### PR DESCRIPTION
I found that I have to send the **\*6\*0*4000#2##** message to turn on the intercom camera.